### PR TITLE
push() was deprecated in WebService::Pushover v0.1.0.

### DIFF
--- a/pushover.pl
+++ b/pushover.pl
@@ -247,5 +247,6 @@ sub _pushover {
     $options{user} = $config{userkey};
     $options{token} = $config{apikey};
 
-    $pushover->push(%options);
+    $pushover->message(%options);
 }
+


### PR DESCRIPTION
Replace it with message().
